### PR TITLE
Qb_interface compatible

### DIFF
--- a/soft_hand_description/model/soft_hand.urdf.xacro
+++ b/soft_hand_description/model/soft_hand.urdf.xacro
@@ -10,7 +10,10 @@
 	<!-- accesories -->
 	<xacro:include filename="$(find soft_hand_description)/model/accesories/kuka_coupler.urdf.xacro"/>
 	<xacro:include filename="$(find soft_hand_description)/model/accesories/clamp.urdf.xacro"/>
+	<xacro:include filename="$(find soft_hand_description)/model/accesories/clamp_30_90.urdf.xacro"/>
 	<xacro:include filename="$(find soft_hand_description)/model/accesories/softhand_base.urdf.xacro"/>
+	<xacro:include filename="$(find soft_hand_description)/model/accesories/merged_angle_flange_30.urdf.xacro"/>
+	<xacro:include filename="$(find soft_hand_description)/model/accesories/merged_angle_flange_90.urdf.xacro"/>
 
 	<!-- joint properties -->
 	<xacro:property name="abd_lb" value="-30" />
@@ -27,6 +30,7 @@
 	<xacro:property name="effort" value="100" />
 	<xacro:property name="damping" value="0.0" />
 	<xacro:property name="friction" value="0.0" />
+	<xacro:property name="pi" value="3.1415926535897931"/>
 
 	<!-- synergy vector -->
 	<xacro:property name="syn_amp" value="1" />
@@ -57,6 +61,7 @@
 	<xacro:property name="max_synergy_effort" value="100" />
 	<xacro:property name="synergy_damping" value="0.0" />
 	<xacro:property name="synergy_friction" value="0.0" />
+	
 
 	<!-- SOFT FINGER model -->
 	<!-- 4 fingers are equal (index, middle, ring, little) -->
@@ -428,14 +433,29 @@
 			<xacro:insert_block name="origin"/>
 		</xacro:kuka_coupler>
 
-		<!-- CLAMP -->
+		<!-- KUKA CLAMP -->
 		<xacro:clamp parent="${name}_kuka_coupler" name="${name}_clamp">
 			<origin xyz="0 0 0.01" rpy="0 0 0"/>
 		</xacro:clamp>
 
+		<!-- 30 DEG FLANGE -->
+		<xacro:flange_30 parent="${name}_clamp" name="${name}_flange_30">
+			<origin xyz="0 0 0.008" rpy="1.5708 0 1.5708"/>
+		</xacro:flange_30>
+
+		<!-- CLAMP 30 - 90 -->
+		<xacro:clamp_30_90 parent="${name}_flange_30" name="${name}_clamp_30_90">
+			<origin xyz="0 0.037 0.012" rpy="0 1.0472 1.5708"/>
+		</xacro:clamp_30_90>
+
+		<!-- 90 DEG FLANGE -->
+		<xacro:flange_90 parent="${name}_clamp_30_90" name="${name}_flange_90">
+			<origin xyz="0.06 0.00 0.008" rpy="1.5708 0 -1.5708"/>
+		</xacro:flange_90>
+
 		<!-- SOFT HAND BASE -->
-		<xacro:softhand_base parent="${name}_clamp" name="${name}_softhand_base" left="${left}">
-			<origin xyz="0 0 0.004" rpy="0 0 0"/>
+		<xacro:softhand_base parent="${name}_flange_90" name="${name}_softhand_base" left="${left}">
+			<origin xyz="0 0.03 0.120" rpy="0 3.1415 -1.5708"/>
 		</xacro:softhand_base>
 
 		<!-- PALM -->

--- a/soft_hand_ros_control/CMakeLists.txt
+++ b/soft_hand_ros_control/CMakeLists.txt
@@ -23,13 +23,6 @@ find_package(catkin REQUIRED COMPONENTS
 ## This assumes you cloned recursively to get he qbAPI sources
 SET(HAND_TOOLS ../hand-tools/qbAPI)
 
-add_service_files(FILES
-  setControlMode.srv
-)
-
-generate_messages(DEPENDENCIES
-  std_msgs
-)
 
 catkin_package(
     INCLUDE_DIRS include

--- a/soft_hand_ros_control/CMakeLists.txt
+++ b/soft_hand_ros_control/CMakeLists.txt
@@ -15,14 +15,14 @@ find_package(catkin REQUIRED COMPONENTS
     tf
     urdf
     pluginlib
-    combined_robot_hw
+ #   combined_robot_hw
 )
 
 
 ## qbAPI is the default electronics the hand is sold with
 ## This assumes you cloned recursively to get he qbAPI sources
 SET(HAND_TOOLS ../hand-tools/qbAPI)
-
+message(${HAND_TOOLS})
 
 catkin_package(
     INCLUDE_DIRS include

--- a/soft_hand_ros_control/config/controllers.yaml
+++ b/soft_hand_ros_control/config/controllers.yaml
@@ -1,16 +1,17 @@
-iit_hand:
-  # Publish all joint states, including mimic joints -----------------------------------
-  joint_state_controller:
-    type: joint_state_controller/JointStateController
-    publish_rate: 100
+soft_hand:
+    iit_hand:
+      # Publish all joint states, including mimic joints -----------------------------------
+      joint_state_controller:
+        type: joint_state_controller/JointStateController
+        publish_rate: 100
 
-  joint_position_controller:
-    type: position_controllers/JointPositionController
-    joint: soft_hand_synergy_joint
+      joint_position_controller:
+        type: position_controllers/JointPositionController
+        joint: soft_hand_synergy_joint
 
-  joint_trajectory_controller:
-    type: position_controllers/JointTrajectoryController
-    joints: 
-      - soft_hand_synergy_joint
-  stiffness: 1.0
-  deadband: 0.0
+      joint_trajectory_controller:
+        type: position_controllers/JointTrajectoryController
+        joints: 
+          - soft_hand_synergy_joint
+      stiffness: 1.0
+      deadband: 0.0

--- a/soft_hand_ros_control/config/joint_names.yaml
+++ b/soft_hand_ros_control/config/joint_names.yaml
@@ -1,3 +1,3 @@
-iit_hand:
-  joints:
-    - soft_hand_synergy_joint
+    iit_hand:
+      joints:
+        - soft_hand_synergy_joint

--- a/soft_hand_ros_control/include/soft_hand_ros_control/definitions.h
+++ b/soft_hand_ros_control/include/soft_hand_ros_control/definitions.h
@@ -12,3 +12,15 @@
 #define DEFAULT_INCREMENT 100 //in tick
 
 #define DEG_TICK_MULTIPLIER (65536.0 / (360.0 * (pow(2, DEFAULT_RESOLUTION))))
+
+// Just thinking of any time in the future the soft hand might have more than one synergy
+#define N_SYN 				1
+#define MAX_HAND_MEAS 		19000.0
+
+// Qb_interface topics
+#define HAND_MEAS_TOPIC 	"/qb_class/hand_measurement"
+#define HAND_CURR_TOPIC 	"/qb_class/hand_current"
+#define HAND_REF_TOPIC 		"/qb_class/hand_ref"
+
+// For debugging: prints out additional info if 1
+#define DEBUG 				1

--- a/soft_hand_ros_control/include/soft_hand_ros_control/iit_hand_hw.h
+++ b/soft_hand_ros_control/include/soft_hand_ros_control/iit_hand_hw.h
@@ -48,8 +48,6 @@
 #include <unistd.h>
 #include "soft_hand_ros_control/definitions.h"
 
-#include "soft_hand_ros_control/setControlMode.h"
-
 // QB interface messages
 #include <qb_interface/handPos.h>
 #include <qb_interface/handCurrent.h>
@@ -134,8 +132,10 @@ public:
         }
     };
 
-    std::shared_ptr<IITSH_HW::IITSH_device> device_;
+    
 private:
+    
+    std::shared_ptr<IITSH_HW::IITSH_device> device_;
     
     ros::NodeHandle nh_;
 

--- a/soft_hand_ros_control/include/soft_hand_ros_control/iit_hand_hw.h
+++ b/soft_hand_ros_control/include/soft_hand_ros_control/iit_hand_hw.h
@@ -46,14 +46,15 @@
 #include <string.h>
 #include <assert.h>
 #include <unistd.h>
-#include "qbmove_communications.h"
 #include "soft_hand_ros_control/definitions.h"
 
 #include "soft_hand_ros_control/setControlMode.h"
 
+// QB interface messages
+#include <qb_interface/handPos.h>
+#include <qb_interface/handCurrent.h>
+#include <qb_interface/handRef.h>
 
-// just thinking of any time in the future the soft hand might have more than one synergy
-constexpr unsigned int N_SYN = 1;
 
 namespace iit_hand_hw {
 class IITSH_HW: public hardware_interface::RobotHW {
@@ -66,6 +67,15 @@ public:
      * @brief Destructor.
      */
     virtual ~IITSH_HW();
+    
+
+    /* Callback functions for the subscribers to qb_interface */
+    void callBackMeas(const qb_interface::handPosConstPtr& pos_msg);
+    void callBackCurr(const qb_interface::handCurrentConstPtr& curr_msg);
+
+    /* Function for initializing correctly the hand variables without NaNs */
+    bool initHandVars();
+
     /**
      * @brief Method implementing all the initialisation required by the class.
      * @param unused node handle
@@ -84,26 +94,7 @@ public:
                              double * const upper_limit,
                              double * const effort_limit);
 
-    int port_selection(const int id, char* my_port);
-    int open_port(char * port);
-    void set_input(short int pos);
-
-    bool set_control_mode(soft_hand_ros_control::setControlMode::Request &req, soft_hand_ros_control::setControlMode::Response &res){
-        // uint8_t control_mode;
-        // if(req.isInPositionMode) control_mode = 0;
-        // else control_mode = 2;
-
-        // commGetParamList(&comm_settings_t_,device_id_,6,&control_mode,1,1,NULL);
-        // usleep(100000);
-        // commStoreParams(&comm_settings_t_,device_id_);
-        // usleep(100000);
-        printf("The control mode service was called, but for now you must have it already set in the hw!!!!! \n");
-
-        isInPositionMode = req.isInPositionMode;
-        isModeSet = true;
-
-        return true;
-    }
+    void set_input(float pos);
 
     struct IITSH_device {
         std::vector<std::string> joint_names;
@@ -142,19 +133,33 @@ public:
             }
         }
     };
-private:
-    std::shared_ptr<IITSH_HW::IITSH_device> device_;
 
+    std::shared_ptr<IITSH_HW::IITSH_device> device_;
+private:
+    
     ros::NodeHandle nh_;
-    float max_tick_ = 19000.0;
-    float max_current_ = 1500.0;
+
+    // A subscriber for getting hand positions from qb_interface
+    ros::Subscriber hand_meas_sub;
+
+    // A subscriber for getting hand currents from qb_interface
+    ros::Subscriber hand_curr_sub;
+
+    // A publisher for publishing hand commands to qb_interface
+    ros::Publisher hand_ref_pub;
+
+    // Variables for temporarily storing hand measurement and current read from topics
+    float hand_meas;
+    short int hand_curr;
+
+    // Variables for storing previous hand measurement and current which are not NaN (used for NaN problem)
+    float prev_hand_meas;
+    short int prev_hand_curr;
+
+    // Variables for storing previous hand command which is not NaN (used for NaN problem)
+    float prev_pos;
 
     int device_id_;
-    comm_settings comm_settings_t_;
-    char port_[255];
-    bool isInPositionMode = true;
-    bool isModeSet = false;
-    ros::ServiceServer controlService;
 
     urdf::Model urdf_model_;
 

--- a/soft_hand_ros_control/launch/soft_hand_hw_all.launch
+++ b/soft_hand_ros_control/launch/soft_hand_hw_all.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
 
 	<!-- LAUNCH INTERFACE -->
@@ -7,20 +8,22 @@
 	<arg name="load_rviz" default="true"/> <!-- to allow launching this file alone -->
 	<arg name="hand_id" default="1"/>
 
-
-    <param name="robot_description" command="$(find xacro)/xacro --inorder $(find adaptive_example)/robot/soft_hand_adaptive.urdf.xacro use_mimic_tag:=true"/>
-   
+<!--
+    <param name="robot_description" command="$(find xacro)/xacro -inorder $(find adaptive_example)/robot/soft_hand_adaptive.urdf.xacro use_mimic_tag:=true"/>
+   -->
+   <!--
     <param name="publish_frequency" value="100"/>
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"  />
-
+-->
     <!-- load controller configurations -->
     <rosparam command="load" file="$(find soft_hand_ros_control)/config/controllers.yaml"/>
     <rosparam command="load" file="$(find soft_hand_ros_control)/config/joint_names.yaml" />
 
 
 	<!-- LAUNCH IMPLEMENTATION -->
-	<group >
-	<node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="true" output="screen"  args="iit_hand/joint_state_controller iit_hand/joint_trajectory_controller"/>
+	<group>
+	<node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="true" output="screen"  args="/soft_hand/iit_hand/joint_state_controller /soft_hand/iit_hand/joint_trajectory_controller"/>
+
 	<param name="device_id" value="$(arg hand_id)"/>
 	<node name="soft_hand_HW" pkg="soft_hand_ros_control" type="iit_hand_hw_node" respawn="false" output="screen"/>
 	</group>

--- a/soft_hand_ros_control/src/iit_hand_hw.cpp
+++ b/soft_hand_ros_control/src/iit_hand_hw.cpp
@@ -42,12 +42,12 @@ namespace iit_hand_hw {
     bool IITSH_HW::init(ros::NodeHandle &n, ros::NodeHandle &robot_hw_nh) {
         nh_ = robot_hw_nh;
 
-        // Initializing subscribers and publishers
+        // // Initializing subscribers and publishers
         hand_meas_sub = nh_.subscribe(std::string(HAND_MEAS_TOPIC), 1000, &iit_hand_hw::IITSH_HW::callBackMeas, this);
         hand_curr_sub = nh_.subscribe(std::string(HAND_CURR_TOPIC), 1000, &iit_hand_hw::IITSH_HW::callBackCurr, this);
         hand_ref_pub = nh_.advertise<qb_interface::handRef>(std::string(HAND_REF_TOPIC), 1000);
 
-        // Initializing hand curr and meas variables
+        // // Initializing hand curr and meas variables
         hand_meas = 0.0; prev_hand_meas = 0.0;
         hand_curr = 0; prev_hand_curr = 0;
         prev_pos = 0.0;
@@ -95,7 +95,7 @@ namespace iit_hand_hw {
         device_ = std::make_shared<IITSH_HW::IITSH_device>();
 
         //nh_.param("device_id", device_id_, BROADCAST_ID);
-        nh_.param("device_id", device_id_, 1);
+        // nh_.param("device_id", device_id_, 1);
 
         // TODO: use transmission configuration to get names directly from the URDF model
         if (ros::param::get("iit_hand/joints", this->device_->joint_names)) {
@@ -144,8 +144,11 @@ namespace iit_hand_hw {
             hardware_interface::JointHandle joint_handle = hardware_interface::JointHandle(
                         state_interface_.getHandle(this->device_->joint_names[i]),
                         &this->device_->joint_position_command[i]);
+            ROS_INFO("HW interface initialized");
 
             position_interface_.registerHandle(joint_handle);
+
+            ROS_INFO("Handle registered");
 
             registerJointLimits(this->device_->joint_names[i],
                                 joint_handle,
@@ -159,7 +162,12 @@ namespace iit_hand_hw {
 
         // register ros-controls interfaces
         this->registerInterface(&state_interface_);
+        ROS_INFO("State interfaces");
         this->registerInterface(&position_interface_);
+        ROS_INFO("Position interfaces");
+
+        return true;
+
     }
 
     void IITSH_HW::stop() {

--- a/soft_hand_ros_control/src/iit_hand_hw.cpp
+++ b/soft_hand_ros_control/src/iit_hand_hw.cpp
@@ -28,7 +28,6 @@
 #include <memory>
 
 #include "soft_hand_ros_control/iit_hand_hw.h"
-#include <std_msgs/Int16MultiArray.h> //joao debug
 #include <pluginlib/class_list_macros.h>
 
 PLUGINLIB_EXPORT_CLASS(iit_hand_hw::IITSH_HW, hardware_interface::RobotHW)
@@ -43,9 +42,52 @@ namespace iit_hand_hw {
     bool IITSH_HW::init(ros::NodeHandle &n, ros::NodeHandle &robot_hw_nh) {
         nh_ = robot_hw_nh;
 
-        controlService = nh_.advertiseService("/setControlMode", &iit_hand_hw::IITSH_HW::set_control_mode, this);
+        // Initializing subscribers and publishers
+        hand_meas_sub = nh_.subscribe(std::string(HAND_MEAS_TOPIC), 1000, &soft_hand_qb_hw::SHHW::callBackMeas, this);
+        hand_curr_sub = nh_.subscribe(std::string(HAND_CURR_TOPIC), 1000, &soft_hand_qb_hw::SHHW::callBackCurr, this);
+        hand_ref_pub = nh_.advertise<qb_interface::handRef>(std::string(HAND_REF_TOPIC), 1000);
+
+        // Initializing hand curr and meas variables
+        hand_meas = 0.0; prev_hand_meas = 0.0;
+        hand_curr = 0; prev_hand_curr = 0;
+        prev_pos = 0.0;
+
+        initHandVars();
 
         return start();
+    }
+
+    /* Callback function for the position subscriber to qb_interface */
+    void IITSH_HW::callBackMeas(const qb_interface::handPosConstPtr& pos_msg){
+        hand_meas = pos_msg->closure[0];
+    }
+
+    /* Callback function for the current subscriber to qb_interface */
+    void IITSH_HW::callBackCurr(const qb_interface::handCurrentConstPtr& curr_msg){
+        hand_curr = curr_msg->current[0];
+    }
+
+    /* Function for initializing correctly the hand variables without NaNs */
+    bool IITSH_HW::initHandVars(){
+        // Writing first non NaN measurement and current to prev variables
+        bool hand_meas_good = false;
+        bool hand_curr_good = false;
+
+        while(!hand_meas_good && !hand_curr_good){
+          if(!std::isnan(hand_meas)){
+            prev_hand_meas = hand_meas;
+            hand_meas_good = true;
+            if(DEBUG) std::cout << "Found good hand measurement: " << prev_hand_meas << "." << std::endl;
+          }
+          if(!std::isnan(hand_curr)){
+            prev_hand_curr = hand_curr;
+            hand_curr_good = true;
+            if(DEBUG) std::cout << "Found good hand current: " << prev_hand_curr << "." << std::endl;
+          }
+
+          if(DEBUG) std::cout << "Exiting initHandVars." << std::endl;
+        }
+
     }
 
     bool IITSH_HW::start() {
@@ -118,89 +160,78 @@ namespace iit_hand_hw {
         // register ros-controls interfaces
         this->registerInterface(&state_interface_);
         this->registerInterface(&position_interface_);
-
-        // Finally, do the qb tools thing
-        // get the port by id
-        /// @todo Abort after a few attempts and print a troubleshoot suggestion:
-        /// 1- is the hand connect to the computer?
-        /// 2- does the user have the appropriate permissions to access serial ports?
-        /// 3- is the device ID set correctly?
-        /// 4- turn on Debug level for further information.
-        while (true) {
-            if (port_selection(device_id_, port_)) {
-                // open the port
-                assert(open_port(port_));
-                // and activate the hand
-                commActivate(&comm_settings_t_, device_id_, 1);
-                ROS_INFO("Initialisation complete");
-                                // int control_mode=CONTROL_CURRENT;
-                //                uint8_t params[512];
-                //                ROS_WARN("CONTROL MODE: %s",params);
-//                int pos_limits[4];
-                //commGetParamList(&comm_settings_t_, device_id_, PARAM_POS_LIMIT, pos_limits, 4, 2, NULL);
-//                ROS_WARN("LIMITS: %d %d %d %d",pos_limits[0],pos_limits[1],pos_limits[2],pos_limits[3]);
-                return true;
-            }
-            else {
-                ROS_WARN_STREAM("Hand " << device_id_
-                                << " not found on any available ports, trying again...");
-                // randomize the waiting to avoid conflict in files (probabilistically speaking)
-                sleep( 4*((double) rand() / (RAND_MAX)) );
-            }
-        }
     }
 
     void IITSH_HW::stop() {
         usleep(2000000);
-        // Deactivate motors
-        commActivate(&comm_settings_t_, device_id_, 0);
-        closeRS485(&comm_settings_t_);
     }
 
     void IITSH_HW::read(const ros::Time &time, const ros::Duration &period) {
-        // update the hand synergy joints
-        // read from hand
-        static short int inputs[2];
-        commGetMeasurements(&comm_settings_t_, device_id_, inputs);
+        // Position and current are already read from hand by the subscribers but check if NaN
+        float non_nan_hand_meas; short int non_nan_hand_curr;
 
-        static short int currents[2];
-        commGetCurrents(&comm_settings_t_, device_id_, currents);
-
-        // fill the state variables
-        for (unsigned int i = 0; i < N_SYN; i++) {
-            this->device_->joint_position_prev[i] = device_->joint_position[i]/1.0;
-            this->device_->joint_position[i] = double(inputs[0]) / max_tick_;
-            float msg_ = this->device_->joint_position[i];
-            // ROS_INFO("Hand says my current position is: %f",  msg_);
-            this->device_->joint_effort[i] = double(currents[0]) * 1.0;
-            this->device_->joint_velocity[i] =
-                    filters::exponentialSmoothing((device_->joint_position[i] - device_->joint_position_prev[i]) / period.toSec(),
-                                                  device_->joint_velocity[i], 0.2);
+        // Check for NaN in hand measurement and update prev meas if not Nan
+        if(std::isnan(hand_meas)){
+          non_nan_hand_meas = prev_hand_meas;
+        } else {
+          non_nan_hand_meas = hand_meas;
+          prev_hand_meas = hand_meas;
         }
+
+        // Check for NaN in hand current and update prev curr if not NaN
+        if(std::isnan(hand_curr)){
+          non_nan_hand_curr = prev_hand_curr;
+        } else {
+          non_nan_hand_curr = hand_curr;
+          prev_hand_curr = hand_curr;
+        }
+          
+        // Setting the inputs using the obtained hand_meas 
+        static float inputs[2];                             // Two elements for future (SoftHand 2.5)
+        inputs[0] = non_nan_hand_meas;
+        inputs[1] = 0.0;
+
+        // Setting the currents using the obtained hand_curr
+        static short int currents[2];                       // Two elements for future (SoftHand 2.5)
+        currents[0] = non_nan_hand_curr;
+        currents[1] = 0;
+
+        // Fill the state variables
+        for(int j = 0; j < N_SYN; j++){
+          this->device_->joint_position_prev[j] = this->device_->joint_position[j];
+          this->device_->joint_position[j] = (double)(inputs[0]/MAX_HAND_MEAS);
+          this->device_->joint_effort[j] = currents[0]*1.0;
+          this->device_->joint_velocity[j] = filters::exponentialSmoothing((this->device_->joint_position[j]-this->device_->joint_position_prev[j])/period.toSec(), this->device_->joint_velocity[j], 0.2);
+        }
+
+        // std::cout << "Measurement is " << this->device_->joint_position[0] << "!" << std::endl;
+        // std::cout << "Previous is " << this->device_->joint_position_prev[0] << "!" << std::endl;
+        // std::cout << "Current is " << this->device_->joint_effort[0] << "!" << std::endl;
+
+        return true;
     }
 
     void IITSH_HW::write(const ros::Time &time, const ros::Duration &period) {
-        // enforce limits
+        // Enforce limits using the period
         pj_sat_interface_.enforceLimits(period);
         pj_limits_interface_.enforceLimits(period);
 
-        
-        short pos;
-        if(isModeSet){
-            if(isInPositionMode){
-                pos = short(max_tick_ * device_->joint_position_command[0]);
-            }
-            else{
-                pos = short(max_current_ * device_->joint_position_command[0]);
-                // ROS_INFO("Commanded position error %f", device_->joint_position_command[0]);
-            }
-        }
-        else{
-            pos = short(0);
+        // Write to the hand the command given by controller manager
+        float pos;
+        pos = (float)(MAX_HAND_MEAS*this->device_->joint_position_command[0]);
+
+        // Check for NaN in hand command and update prev pos if not Nan
+        if(std::isnan(pos)){
+          pos = prev_pos;
+        } else {
+          prev_pos = pos;
         }
         
+        // std::cout << "Command is " << pos << "!" << std::endl;
 
         set_input(pos);
+
+        return;
     }
 
     void IITSH_HW::registerJointLimits(const std::string &joint_name,
@@ -254,83 +285,19 @@ namespace iit_hand_hw {
         }
     }
 
-    int IITSH_HW::port_selection(const int id, char *my_port) {
-        int num_ports = 0;
-        char ports[10][255];
-
-        num_ports = RS485listPorts(ports);
-
-        ROS_DEBUG_STREAM("Search ID " << device_id_ << " in "
-                         << num_ports << " serial ports available...");
-
-        if (num_ports) {
-            for (int i = 0; i < num_ports; i++) {
-                ROS_DEBUG_STREAM("Checking port: " << ports[i]);
-
-                int aux_int;
-                comm_settings comm_settings_t;
-                char list_of_devices[255];
-
-                openRS485(&comm_settings_t, ports[i]);
-
-                if (comm_settings_t.file_handle == INVALID_HANDLE_VALUE) {
-                    ROS_DEBUG_STREAM("Couldn't connect to the serial port. Continue with the next available.");
-                    continue;
-                }
-
-                aux_int = RS485ListDevices(&comm_settings_t, list_of_devices);
-
-                ROS_DEBUG_STREAM( "Number of devices: " << aux_int );
-
-                if (aux_int > 2 || aux_int < 0) {
-                    ROS_WARN("The current port has more than one or none device connected... that is not a SoftHand");
-                }
-                else {
-                    ROS_DEBUG_STREAM("List of devices:");
-                    for (int d = 0; d < aux_int; ++d) {
-                        ROS_DEBUG_STREAM( static_cast<int>(list_of_devices[d]) );
-                        ROS_DEBUG_STREAM( "searching id" << id );
-                        if (static_cast<int>(list_of_devices[d]) == id) {
-                            ROS_DEBUG_STREAM("Hand found at port: " << ports[i] << " !");
-                            strcpy(my_port, ports[i]);
-                            closeRS485(&comm_settings_t);
-                            sleep(1);
-                            return 1;
-                        }
-                        sleep(1);
-                    }
-                }
-                closeRS485(&comm_settings_t);
-            }
-            return 0;
-        }
-        else {
-            ROS_ERROR("No serial port available.");
-            return 0;
-        }
-    }
-
-    int IITSH_HW::open_port(char * port) {
-        ROS_DEBUG_STREAM("Opening serial port: " << port << " for hand_id: " << device_id_);
-        fflush(stdout);
-
-        openRS485(&comm_settings_t_, port);
-
-        if (comm_settings_t_.file_handle == INVALID_HANDLE_VALUE) {
-            ROS_ERROR("Couldn't connect to the selected serial port.");
-            return 0;
-        }
-        usleep(500000);
-        ROS_DEBUG_STREAM("Serial port " << port << " open");
-        return 1;
-    }
-
     void IITSH_HW::set_input(short pos) {
-        static short int inputs[2];
+        static float inputs[2];
 
         inputs[0] = pos;
-        inputs[1] = 0;
+        inputs[1] = 0.0;
 
-        commSetInputs(&comm_settings_t_, device_id_, inputs);
+        // Creating the Hand Ref message for qb_interface
+        qb_interface::handRef tmp_ref_msg;
+        tmp_ref_msg.closure.push_back(inputs[0]);
+
+        // Publishing the command to robot though qb_interface
+        hand_ref_pub.publish(tmp_ref_msg);
+
+        return;
     }
 }

--- a/soft_hand_ros_control/src/iit_hand_hw.cpp
+++ b/soft_hand_ros_control/src/iit_hand_hw.cpp
@@ -43,8 +43,8 @@ namespace iit_hand_hw {
         nh_ = robot_hw_nh;
 
         // Initializing subscribers and publishers
-        hand_meas_sub = nh_.subscribe(std::string(HAND_MEAS_TOPIC), 1000, &soft_hand_qb_hw::SHHW::callBackMeas, this);
-        hand_curr_sub = nh_.subscribe(std::string(HAND_CURR_TOPIC), 1000, &soft_hand_qb_hw::SHHW::callBackCurr, this);
+        hand_meas_sub = nh_.subscribe(std::string(HAND_MEAS_TOPIC), 1000, &iit_hand_hw::IITSH_HW::callBackMeas, this);
+        hand_curr_sub = nh_.subscribe(std::string(HAND_CURR_TOPIC), 1000, &iit_hand_hw::IITSH_HW::callBackCurr, this);
         hand_ref_pub = nh_.advertise<qb_interface::handRef>(std::string(HAND_REF_TOPIC), 1000);
 
         // Initializing hand curr and meas variables
@@ -208,7 +208,7 @@ namespace iit_hand_hw {
         // std::cout << "Previous is " << this->device_->joint_position_prev[0] << "!" << std::endl;
         // std::cout << "Current is " << this->device_->joint_effort[0] << "!" << std::endl;
 
-        return true;
+        return;
     }
 
     void IITSH_HW::write(const ros::Time &time, const ros::Duration &period) {
@@ -285,7 +285,7 @@ namespace iit_hand_hw {
         }
     }
 
-    void IITSH_HW::set_input(short pos) {
+    void IITSH_HW::set_input(float pos) {
         static float inputs[2];
 
         inputs[0] = pos;

--- a/soft_hand_ros_control/src/iit_hand_hw.cpp
+++ b/soft_hand_ros_control/src/iit_hand_hw.cpp
@@ -42,12 +42,12 @@ namespace iit_hand_hw {
     bool IITSH_HW::init(ros::NodeHandle &n, ros::NodeHandle &robot_hw_nh) {
         nh_ = robot_hw_nh;
 
-        // // Initializing subscribers and publishers
+        // Initializing subscribers and publishers
         hand_meas_sub = nh_.subscribe(std::string(HAND_MEAS_TOPIC), 1000, &iit_hand_hw::IITSH_HW::callBackMeas, this);
         hand_curr_sub = nh_.subscribe(std::string(HAND_CURR_TOPIC), 1000, &iit_hand_hw::IITSH_HW::callBackCurr, this);
         hand_ref_pub = nh_.advertise<qb_interface::handRef>(std::string(HAND_REF_TOPIC), 1000);
 
-        // // Initializing hand curr and meas variables
+        // Initializing hand curr and meas variables
         hand_meas = 0.0; prev_hand_meas = 0.0;
         hand_curr = 0; prev_hand_curr = 0;
         prev_pos = 0.0;
@@ -144,11 +144,8 @@ namespace iit_hand_hw {
             hardware_interface::JointHandle joint_handle = hardware_interface::JointHandle(
                         state_interface_.getHandle(this->device_->joint_names[i]),
                         &this->device_->joint_position_command[i]);
-            ROS_INFO("HW interface initialized");
 
             position_interface_.registerHandle(joint_handle);
-
-            ROS_INFO("Handle registered");
 
             registerJointLimits(this->device_->joint_names[i],
                                 joint_handle,
@@ -158,14 +155,10 @@ namespace iit_hand_hw {
                                 &this->device_->joint_effort_limits[i]);
         }
 
-        ROS_INFO("Register state and position interfaces");
-
         // register ros-controls interfaces
         this->registerInterface(&state_interface_);
-        ROS_INFO("State interfaces");
         this->registerInterface(&position_interface_);
-        ROS_INFO("Position interfaces");
-
+        
         return true;
 
     }

--- a/soft_hand_ros_control/src/iit_hand_hw_node.cpp
+++ b/soft_hand_ros_control/src/iit_hand_hw_node.cpp
@@ -62,8 +62,6 @@ int main( int argc, char** argv )
   // initialisation/configuration routine
   iit_softhand.init(iit_nh, iit_nh);
 
-  ROS_INFO("I crashed");
-
   // timer variables
   struct timespec ts = {0, 0};
   ros::Time last(ts.tv_sec, ts.tv_nsec), now(ts.tv_sec, ts.tv_nsec);

--- a/soft_hand_ros_control/src/iit_hand_hw_node.cpp
+++ b/soft_hand_ros_control/src/iit_hand_hw_node.cpp
@@ -31,7 +31,7 @@
 #include <signal.h>
 #include <stdexcept>
 
-constexpr int CTRL_FREQ = 1000; // Hz
+// constexpr int CTRL_FREQ = 1000; // Hz
 
 bool g_quit = false;
 
@@ -57,7 +57,7 @@ int main( int argc, char** argv )
   ros::NodeHandle iit_nh;
   iit_hand_hw::IITSH_HW iit_softhand;
 
-  ros::Rate loop_rate(CTRL_FREQ);
+  // ros::Rate loop_rate(CTRL_FREQ);
 
   // initialisation/configuration routine
   iit_softhand.init(iit_nh, iit_nh);
@@ -92,7 +92,7 @@ int main( int argc, char** argv )
     // write the command to the iit softhand
     iit_softhand.write(now, period);
 
-    loop_rate.sleep();
+    // loop_rate.sleep();
   }
 
   std::cerr <<" Stopping spinner..." << std::endl;

--- a/soft_hand_ros_control/src/iit_hand_hw_node.cpp
+++ b/soft_hand_ros_control/src/iit_hand_hw_node.cpp
@@ -31,7 +31,7 @@
 #include <signal.h>
 #include <stdexcept>
 
-// constexpr int CTRL_FREQ = 1000; // Hz
+constexpr int CTRL_FREQ = 1000; // Hz
 
 bool g_quit = false;
 
@@ -57,10 +57,12 @@ int main( int argc, char** argv )
   ros::NodeHandle iit_nh;
   iit_hand_hw::IITSH_HW iit_softhand;
 
-  // ros::Rate loop_rate(CTRL_FREQ);
+  ros::Rate loop_rate(CTRL_FREQ);
 
   // initialisation/configuration routine
   iit_softhand.init(iit_nh, iit_nh);
+
+  ROS_INFO("I crashed");
 
   // timer variables
   struct timespec ts = {0, 0};
@@ -92,7 +94,7 @@ int main( int argc, char** argv )
     // write the command to the iit softhand
     iit_softhand.write(now, period);
 
-    // loop_rate.sleep();
+    loop_rate.sleep();
   }
 
   std::cerr <<" Stopping spinner..." << std::endl;

--- a/soft_hand_ros_control/srv/setControlMode.srv
+++ b/soft_hand_ros_control/srv/setControlMode.srv
@@ -1,2 +1,0 @@
-bool isInPositionMode
----


### PR DESCRIPTION
The `qb-compatible` branch contains changes to make the new `iit_hand_hw` node compatible with `qb_interface` while preserving compatibility with the `combined_robot_hw`. Also, the service that would set the control mode for the hand is now removed as IIT's controller will be implemented by changing the gain of the hand's PID controller via the `qb_interface` @psotiropoulos  @hmn-ocado.